### PR TITLE
Add Textual frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# DBADMIN-CODEX
+
+This repository provides a Bash script (`dbdeenkus.sh`) for diagnosing and recovering Fly.io PostgreSQL clusters. A simple Textual front‑end (`frontend.py`) is also included to make common tasks accessible from a menu driven interface.
+
+## Requirements
+
+- Bash
+- Python 3.10+
+- [Textual](https://github.com/Textualize/textual) (`pip install textual`)
+
+## Usage
+
+Run the Textual front end:
+
+```bash
+python frontend.py
+```
+
+Select an action from the menu to run the corresponding option from `dbdeenkus.sh`.
+
+The original Bash script can still be executed directly if preferred:
+
+```bash
+bash dbdeenkus.sh
+```

--- a/frontend.py
+++ b/frontend.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import subprocess
+
+from textual.app import App, ComposeResult
+from textual.widgets import Header, Footer, Button, Static
+from textual.containers import Vertical
+
+SCRIPT_PATH = Path(__file__).parent / "dbdeenkus.sh"
+
+class RecoveryApp(App):
+    MENU = [
+        ("Check cluster status", "1"),
+        ("Check database connectivity", "2"),
+        ("Check PostgreSQL cluster status", "3"),
+        ("Check repmgr status", "4"),
+        ("Check machine resources", "5"),
+        ("Check DNS resolution", "6"),
+        ("Create backup", "7"),
+        ("Restart failed machines only", "8"),
+        ("Force restart ALL machines", "9"),
+        ("Attempt PostgreSQL recovery", "10"),
+        ("Promote standby to primary", "11"),
+        ("Scale restart", "12"),
+        ("Check error logs", "13"),
+        ("Full diagnostic report", "14"),
+        ("Auto recovery", "15"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static("Fly.io PostgreSQL Recovery", id="title")
+        with Vertical(id="menu"):
+            for label, _ in self.MENU:
+                yield Button(label, id=label)
+        yield Button("Exit", id="exit")
+        yield Footer()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        label = event.button.id
+        if label == "exit":
+            self.exit()
+            return
+        # Find the corresponding choice number
+        for text, num in self.MENU:
+            if text == label:
+                choice = num
+                break
+        else:
+            return
+        # Run the shell script with the choice and exit command
+        subprocess.run(["bash", str(SCRIPT_PATH)], input=f"{choice}\n0\n", text=True)
+
+if __name__ == "__main__":
+    RecoveryApp().run()


### PR DESCRIPTION
## Summary
- add a Textual-based frontend to drive the `dbdeenkus.sh` script
- document usage and requirements in README

## Testing
- `python3 -m py_compile frontend.py`
- `bash -n dbdeenkus.sh`
- `shellcheck dbdeenkus.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850581d5f84832a9ede6b574b8d3fa8